### PR TITLE
Use newer APIs for appsv1 and networkingv1beta1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,43 +21,43 @@ generate: generate-types generate-type-tests generate-joins
 
 generate-types:
 	genny -in=types/gen/template.go -out=types/pod/generated.go -pkg=pod gen 'ObjectType=*corev1.Pod'
-	genny -in=types/gen/template.go -out=types/ingress/generated.go -pkg=ingress gen 'ObjectType=*extv1beta1.Ingress'
+	genny -in=types/gen/template.go -out=types/ingress/generated.go -pkg=ingress gen 'ObjectType=*networkingv1beta1.Ingress'
 	genny -in=types/gen/template.go -out=types/secret/generated.go -pkg=secret gen 'ObjectType=*corev1.Secret'
 	genny -in=types/gen/template.go -out=types/service/generated.go -pkg=service gen 'ObjectType=*corev1.Service'
 	genny -in=types/gen/template.go -out=types/event/generated.go -pkg=event gen 'ObjectType=*corev1.Event'
 	genny -in=types/gen/template.go -out=types/node/generated.go -pkg=node gen 'ObjectType=*corev1.Node'
 	genny -in=types/gen/template.go -out=types/replicationcontroller/generated.go -pkg=replicationcontroller gen 'ObjectType=*corev1.ReplicationController'
-	genny -in=types/gen/template.go -out=types/replicaset/generated.go -pkg=replicaset gen 'ObjectType=*extv1beta1.ReplicaSet'
-	genny -in=types/gen/template.go -out=types/deployment/generated.go -pkg=deployment gen 'ObjectType=*extv1beta1.Deployment'
+	genny -in=types/gen/template.go -out=types/replicaset/generated.go -pkg=replicaset gen 'ObjectType=*appsv1.ReplicaSet'
+	genny -in=types/gen/template.go -out=types/deployment/generated.go -pkg=deployment gen 'ObjectType=*appsv1.Deployment'
 	genny -in=types/gen/template.go -out=types/job/generated.go -pkg=job gen 'ObjectType=*batchv1.Job'
-	genny -in=types/gen/template.go -out=types/daemonset/generated.go -pkg=daemonset gen 'ObjectType=*extv1beta1.DaemonSet'
+	genny -in=types/gen/template.go -out=types/daemonset/generated.go -pkg=daemonset gen 'ObjectType=*appsv1.DaemonSet'
 	goimports -w types/**/generated.go
 	$(GO) build ./types/...
 
 generate-type-tests:
 	$(GO) build -o ./types/gen/gen ./types/gen
 	./types/gen/gen corev1.Pod > types/pod/generated_test.go
-	./types/gen/gen extv1beta1.Ingress > types/ingress/generated_test.go
+	./types/gen/gen networkingv1beta1.Ingress > types/ingress/generated_test.go
 	./types/gen/gen corev1.Secret > types/secret/generated_test.go
 	./types/gen/gen corev1.Service > types/service/generated_test.go
 	./types/gen/gen corev1.Event > types/event/generated_test.go
 	./types/gen/gen corev1.Node > types/node/generated_test.go
 	./types/gen/gen corev1.ReplicationController > types/replicationcontroller/generated_test.go
-	./types/gen/gen extv1beta1.ReplicaSet > types/replicaset/generated_test.go
-	./types/gen/gen extv1beta1.Deployment > types/deployment/generated_test.go
+	./types/gen/gen appsv1.ReplicaSet > types/replicaset/generated_test.go
+	./types/gen/gen appsv1.Deployment > types/deployment/generated_test.go
 	./types/gen/gen batchv1.Job > types/job/generated_test.go
-	./types/gen/gen extv1beta1.DaemonSet > types/daemonset/generated_test.go
+	./types/gen/gen appsv1.DaemonSet > types/daemonset/generated_test.go
 	$(GO) test ./types/...
 
 generate-joins:
 	go build -o ./join/gen/gen ./join/gen
 	./join/gen/gen Service service '*corev1.Service' Pod pod > ./join/generated_service_pod.go
 	./join/gen/gen RC  replicationcontroller '*corev1.ReplicationController' Pod pod > ./join/generated_rc_pod.go
-	./join/gen/gen RS  replicaset '*extv1beta1.ReplicaSet' Pod pod > ./join/generated_rs_pod.go
-	./join/gen/gen Deployment deployment '*extv1beta1.Deployment' Pod pod > ./join/generated_deployment_pod.go
+	./join/gen/gen RS  replicaset '*appsv1.ReplicaSet' Pod pod > ./join/generated_rs_pod.go
+	./join/gen/gen Deployment deployment '*appsv1.Deployment' Pod pod > ./join/generated_deployment_pod.go
 	./join/gen/gen Job job '*batchv1.Job' Pod pod > ./join/generated_job_pod.go
-	./join/gen/gen DaemonSet daemonset '*extv1beta1.DaemonSet' Pod pod > ./join/generated_daemonset_pod.go
-	./join/gen/gen Ingress ingress '*extv1beta1.Ingress' Service service > ./join/generated_ingress_service.go
+	./join/gen/gen DaemonSet daemonset '*appsv1.DaemonSet' Pod pod > ./join/generated_daemonset_pod.go
+	./join/gen/gen Ingress ingress '*networkingv1beta1.Ingress' Service service > ./join/generated_ingress_service.go
 	$(GO) build ./join
 
 example:

--- a/client/client.go
+++ b/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -66,13 +67,17 @@ func ForResource(
 func makeResourceListFn(
 	c restRequester, res string, ns string) ListFn {
 	return func(ctx context.Context, opts metav1.ListOptions) (runtime.Object, error) {
-		return c.Get().
+		result := c.Get().
 			Context(ctx).
 			Namespace(ns).
 			Resource(res).
 			VersionedParams(&opts, scheme.ParameterCodec).
-			Do().
-			Get()
+			Do()
+		err := result.Error()
+		if err != nil {
+			return nil, fmt.Errorf("listing %s in %s: %w", res, ns, err)
+		}
+		return result.Get()
 	}
 }
 

--- a/join/fiximport.go
+++ b/join/fiximport.go
@@ -1,9 +1,10 @@
 package join
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -14,8 +15,8 @@ var _ corev1.Service
 var _ corev1.Event
 var _ corev1.Node
 var _ corev1.ReplicationController
-var _ extv1beta1.Deployment
-var _ extv1beta1.Ingress
-var _ extv1beta1.ReplicaSet
-var _ extv1beta1.DaemonSet
+var _ appsv1.Deployment
+var _ networkingv1beta1.Ingress
+var _ appsv1.ReplicaSet
+var _ appsv1.DaemonSet
 var _ batchv1.Job

--- a/join/generated_daemonset_pod.go
+++ b/join/generated_daemonset_pod.go
@@ -11,13 +11,13 @@ import (
 	"github.com/boz/kcache/filter"
 	"github.com/boz/kcache/types/daemonset"
 	"github.com/boz/kcache/types/pod"
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 )
 
 func DaemonSetPodsWith(ctx context.Context,
 	srcController daemonset.Controller,
 	dstController pod.Publisher,
-	filterFn func(...*extv1beta1.DaemonSet) filter.ComparableFilter) (pod.Controller, error) {
+	filterFn func(...*appsv1.DaemonSet) filter.ComparableFilter) (pod.Controller, error) {
 
 	log := logutil.FromContextOrDefault(ctx)
 
@@ -26,7 +26,7 @@ func DaemonSetPodsWith(ctx context.Context,
 		return nil, err
 	}
 
-	update := func(_ *extv1beta1.DaemonSet) {
+	update := func(_ *appsv1.DaemonSet) {
 		objs, err := srcController.Cache().List()
 		if err != nil {
 			log.Err(err, "join(daemonset,pod: cache list")
@@ -36,7 +36,7 @@ func DaemonSetPodsWith(ctx context.Context,
 	}
 
 	handler := daemonset.BuildHandler().
-		OnInitialize(func(objs []*extv1beta1.DaemonSet) { dst.Refilter(filterFn(objs...)) }).
+		OnInitialize(func(objs []*appsv1.DaemonSet) { dst.Refilter(filterFn(objs...)) }).
 		OnCreate(update).
 		OnUpdate(update).
 		OnDelete(update).

--- a/join/generated_deployment_pod.go
+++ b/join/generated_deployment_pod.go
@@ -11,13 +11,13 @@ import (
 	"github.com/boz/kcache/filter"
 	"github.com/boz/kcache/types/deployment"
 	"github.com/boz/kcache/types/pod"
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 )
 
 func DeploymentPodsWith(ctx context.Context,
 	srcController deployment.Controller,
 	dstController pod.Publisher,
-	filterFn func(...*extv1beta1.Deployment) filter.ComparableFilter) (pod.Controller, error) {
+	filterFn func(...*appsv1.Deployment) filter.ComparableFilter) (pod.Controller, error) {
 
 	log := logutil.FromContextOrDefault(ctx)
 
@@ -26,7 +26,7 @@ func DeploymentPodsWith(ctx context.Context,
 		return nil, err
 	}
 
-	update := func(_ *extv1beta1.Deployment) {
+	update := func(_ *appsv1.Deployment) {
 		objs, err := srcController.Cache().List()
 		if err != nil {
 			log.Err(err, "join(deployment,pod: cache list")
@@ -36,7 +36,7 @@ func DeploymentPodsWith(ctx context.Context,
 	}
 
 	handler := deployment.BuildHandler().
-		OnInitialize(func(objs []*extv1beta1.Deployment) { dst.Refilter(filterFn(objs...)) }).
+		OnInitialize(func(objs []*appsv1.Deployment) { dst.Refilter(filterFn(objs...)) }).
 		OnCreate(update).
 		OnUpdate(update).
 		OnDelete(update).

--- a/join/generated_ingress_service.go
+++ b/join/generated_ingress_service.go
@@ -11,13 +11,13 @@ import (
 	"github.com/boz/kcache/filter"
 	"github.com/boz/kcache/types/ingress"
 	"github.com/boz/kcache/types/service"
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 )
 
 func IngressServicesWith(ctx context.Context,
 	srcController ingress.Controller,
 	dstController service.Publisher,
-	filterFn func(...*extv1beta1.Ingress) filter.ComparableFilter) (service.Controller, error) {
+	filterFn func(...*networkingv1beta1.Ingress) filter.ComparableFilter) (service.Controller, error) {
 
 	log := logutil.FromContextOrDefault(ctx)
 
@@ -26,7 +26,7 @@ func IngressServicesWith(ctx context.Context,
 		return nil, err
 	}
 
-	update := func(_ *extv1beta1.Ingress) {
+	update := func(_ *networkingv1beta1.Ingress) {
 		objs, err := srcController.Cache().List()
 		if err != nil {
 			log.Err(err, "join(ingress,service: cache list")
@@ -36,7 +36,7 @@ func IngressServicesWith(ctx context.Context,
 	}
 
 	handler := ingress.BuildHandler().
-		OnInitialize(func(objs []*extv1beta1.Ingress) { dst.Refilter(filterFn(objs...)) }).
+		OnInitialize(func(objs []*networkingv1beta1.Ingress) { dst.Refilter(filterFn(objs...)) }).
 		OnCreate(update).
 		OnUpdate(update).
 		OnDelete(update).

--- a/join/generated_rs_pod.go
+++ b/join/generated_rs_pod.go
@@ -11,13 +11,13 @@ import (
 	"github.com/boz/kcache/filter"
 	"github.com/boz/kcache/types/pod"
 	"github.com/boz/kcache/types/replicaset"
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 )
 
 func RSPodsWith(ctx context.Context,
 	srcController replicaset.Controller,
 	dstController pod.Publisher,
-	filterFn func(...*extv1beta1.ReplicaSet) filter.ComparableFilter) (pod.Controller, error) {
+	filterFn func(...*appsv1.ReplicaSet) filter.ComparableFilter) (pod.Controller, error) {
 
 	log := logutil.FromContextOrDefault(ctx)
 
@@ -26,7 +26,7 @@ func RSPodsWith(ctx context.Context,
 		return nil, err
 	}
 
-	update := func(_ *extv1beta1.ReplicaSet) {
+	update := func(_ *appsv1.ReplicaSet) {
 		objs, err := srcController.Cache().List()
 		if err != nil {
 			log.Err(err, "join(replicaset,pod: cache list")
@@ -36,7 +36,7 @@ func RSPodsWith(ctx context.Context,
 	}
 
 	handler := replicaset.BuildHandler().
-		OnInitialize(func(objs []*extv1beta1.ReplicaSet) { dst.Refilter(filterFn(objs...)) }).
+		OnInitialize(func(objs []*appsv1.ReplicaSet) { dst.Refilter(filterFn(objs...)) }).
 		OnCreate(update).
 		OnUpdate(update).
 		OnDelete(update).

--- a/types/daemonset/client.go
+++ b/types/daemonset/client.go
@@ -8,6 +8,6 @@ import (
 const resourceName = "daemonsets"
 
 func NewClient(cs kubernetes.Interface, ns string) client.Client {
-	scope := cs.ExtensionsV1beta1()
+	scope := cs.AppsV1()
 	return client.ForResource(scope.RESTClient(), resourceName, ns)
 }

--- a/types/daemonset/filter.go
+++ b/types/daemonset/filter.go
@@ -3,16 +3,16 @@ package daemonset
 import (
 	"sort"
 
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 
 	"github.com/boz/kcache/filter"
 	"github.com/boz/kcache/nsname"
 )
 
-func PodsFilter(sources ...*extv1beta1.DaemonSet) filter.ComparableFilter {
+func PodsFilter(sources ...*appsv1.DaemonSet) filter.ComparableFilter {
 
 	// make a copy and sort
-	srcs := make([]*extv1beta1.DaemonSet, len(sources))
+	srcs := make([]*appsv1.DaemonSet, len(sources))
 	copy(srcs, sources)
 
 	sort.Slice(srcs, func(i, j int) bool {

--- a/types/daemonset/filter_test.go
+++ b/types/daemonset/filter_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/boz/kcache/types/daemonset"
 	"github.com/stretchr/testify/assert"
+	v1beta1 "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/types/daemonset/fiximport.go
+++ b/types/daemonset/fiximport.go
@@ -1,9 +1,10 @@
 package daemonset
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -14,8 +15,8 @@ var _ corev1.Service
 var _ corev1.Event
 var _ corev1.Node
 var _ corev1.ReplicationController
-var _ extv1beta1.Deployment
-var _ extv1beta1.Ingress
-var _ extv1beta1.ReplicaSet
-var _ extv1beta1.DaemonSet
+var _ appsv1.Deployment
+var _ networkingv1beta1.Ingress
+var _ appsv1.ReplicaSet
+var _ appsv1.DaemonSet
 var _ batchv1.Job

--- a/types/daemonset/generated.go
+++ b/types/daemonset/generated.go
@@ -12,7 +12,7 @@ import (
 	"github.com/boz/kcache"
 	"github.com/boz/kcache/client"
 	"github.com/boz/kcache/filter"
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -22,16 +22,16 @@ var (
 	adapter        = _adapter{}
 )
 
-var _ = extv1beta1.Deployment{}
+var _ = appsv1.Deployment{}
 
 type Event interface {
 	Type() kcache.EventType
-	Resource() *extv1beta1.DaemonSet
+	Resource() *appsv1.DaemonSet
 }
 
 type CacheReader interface {
-	Get(ns string, name string) (*extv1beta1.DaemonSet, error)
-	List() ([]*extv1beta1.DaemonSet, error)
+	Get(ns string, name string) (*appsv1.DaemonSet, error)
+	List() ([]*appsv1.DaemonSet, error)
 }
 
 type CacheController interface {
@@ -74,48 +74,48 @@ type FilterController interface {
 }
 
 type BaseHandler interface {
-	OnCreate(*extv1beta1.DaemonSet)
-	OnUpdate(*extv1beta1.DaemonSet)
-	OnDelete(*extv1beta1.DaemonSet)
+	OnCreate(*appsv1.DaemonSet)
+	OnUpdate(*appsv1.DaemonSet)
+	OnDelete(*appsv1.DaemonSet)
 }
 
 type Handler interface {
 	BaseHandler
-	OnInitialize([]*extv1beta1.DaemonSet)
+	OnInitialize([]*appsv1.DaemonSet)
 }
 
 type HandlerBuilder interface {
-	OnInitialize(func([]*extv1beta1.DaemonSet)) HandlerBuilder
-	OnCreate(func(*extv1beta1.DaemonSet)) HandlerBuilder
-	OnUpdate(func(*extv1beta1.DaemonSet)) HandlerBuilder
-	OnDelete(func(*extv1beta1.DaemonSet)) HandlerBuilder
+	OnInitialize(func([]*appsv1.DaemonSet)) HandlerBuilder
+	OnCreate(func(*appsv1.DaemonSet)) HandlerBuilder
+	OnUpdate(func(*appsv1.DaemonSet)) HandlerBuilder
+	OnDelete(func(*appsv1.DaemonSet)) HandlerBuilder
 	Create() Handler
 }
 
 type UnitaryHandler interface {
 	BaseHandler
-	OnInitialize(*extv1beta1.DaemonSet)
+	OnInitialize(*appsv1.DaemonSet)
 }
 
 type UnitaryHandlerBuilder interface {
-	OnInitialize(func(*extv1beta1.DaemonSet)) UnitaryHandlerBuilder
-	OnCreate(func(*extv1beta1.DaemonSet)) UnitaryHandlerBuilder
-	OnUpdate(func(*extv1beta1.DaemonSet)) UnitaryHandlerBuilder
-	OnDelete(func(*extv1beta1.DaemonSet)) UnitaryHandlerBuilder
+	OnInitialize(func(*appsv1.DaemonSet)) UnitaryHandlerBuilder
+	OnCreate(func(*appsv1.DaemonSet)) UnitaryHandlerBuilder
+	OnUpdate(func(*appsv1.DaemonSet)) UnitaryHandlerBuilder
+	OnDelete(func(*appsv1.DaemonSet)) UnitaryHandlerBuilder
 	Create() UnitaryHandler
 }
 
 type _adapter struct{}
 
-func (_adapter) adaptObject(obj metav1.Object) (*extv1beta1.DaemonSet, error) {
-	if obj, ok := obj.(*extv1beta1.DaemonSet); ok {
+func (_adapter) adaptObject(obj metav1.Object) (*appsv1.DaemonSet, error) {
+	if obj, ok := obj.(*appsv1.DaemonSet); ok {
 		return obj, nil
 	}
 	return nil, ErrInvalidType
 }
 
-func (a _adapter) adaptList(objs []metav1.Object) ([]*extv1beta1.DaemonSet, error) {
-	var ret []*extv1beta1.DaemonSet
+func (a _adapter) adaptList(objs []metav1.Object) ([]*appsv1.DaemonSet, error) {
+	var ret []*appsv1.DaemonSet
 	for _, orig := range objs {
 		adapted, err := a.adaptObject(orig)
 		if err != nil {
@@ -134,7 +134,7 @@ type cache struct {
 	parent kcache.CacheReader
 }
 
-func (c *cache) Get(ns string, name string) (*extv1beta1.DaemonSet, error) {
+func (c *cache) Get(ns string, name string) (*appsv1.DaemonSet, error) {
 	obj, err := c.parent.Get(ns, name)
 	switch {
 	case err != nil:
@@ -146,7 +146,7 @@ func (c *cache) Get(ns string, name string) (*extv1beta1.DaemonSet, error) {
 	}
 }
 
-func (c *cache) List() ([]*extv1beta1.DaemonSet, error) {
+func (c *cache) List() ([]*appsv1.DaemonSet, error) {
 	objs, err := c.parent.List()
 	if err != nil {
 		return nil, err
@@ -156,7 +156,7 @@ func (c *cache) List() ([]*extv1beta1.DaemonSet, error) {
 
 type event struct {
 	etype    kcache.EventType
-	resource *extv1beta1.DaemonSet
+	resource *appsv1.DaemonSet
 }
 
 func wrapEvent(evt kcache.Event) (Event, error) {
@@ -171,7 +171,7 @@ func (e event) Type() kcache.EventType {
 	return e.etype
 }
 
-func (e event) Resource() *extv1beta1.DaemonSet {
+func (e event) Resource() *appsv1.DaemonSet {
 	return e.resource
 }
 
@@ -378,7 +378,7 @@ func NewMonitor(publisher Publisher, handler Handler) (kcache.Monitor, error) {
 
 func ToUnitary(log logutil.Log, delegate UnitaryHandler) Handler {
 	return BuildHandler().
-		OnInitialize(func(objs []*extv1beta1.DaemonSet) {
+		OnInitialize(func(objs []*appsv1.DaemonSet) {
 			if count := len(objs); count > 1 {
 				log.Warnf("initialized with invalid count: %v", count)
 				return
@@ -389,13 +389,13 @@ func ToUnitary(log logutil.Log, delegate UnitaryHandler) Handler {
 			}
 			delegate.OnInitialize(objs[0])
 		}).
-		OnCreate(func(obj *extv1beta1.DaemonSet) {
+		OnCreate(func(obj *appsv1.DaemonSet) {
 			delegate.OnCreate(obj)
 		}).
-		OnUpdate(func(obj *extv1beta1.DaemonSet) {
+		OnUpdate(func(obj *appsv1.DaemonSet) {
 			delegate.OnUpdate(obj)
 		}).
-		OnDelete(func(obj *extv1beta1.DaemonSet) {
+		OnDelete(func(obj *appsv1.DaemonSet) {
 			delegate.OnDelete(obj)
 		}).Create()
 }
@@ -409,39 +409,39 @@ func BuildUnitaryHandler() UnitaryHandlerBuilder {
 }
 
 type baseHandler struct {
-	onCreate func(*extv1beta1.DaemonSet)
-	onUpdate func(*extv1beta1.DaemonSet)
-	onDelete func(*extv1beta1.DaemonSet)
+	onCreate func(*appsv1.DaemonSet)
+	onUpdate func(*appsv1.DaemonSet)
+	onDelete func(*appsv1.DaemonSet)
 }
 
 type handler struct {
 	baseHandler
-	onInitialize func([]*extv1beta1.DaemonSet)
+	onInitialize func([]*appsv1.DaemonSet)
 }
 type handlerBuilder handler
 
 type unitaryHandler struct {
 	baseHandler
-	onInitialize func(*extv1beta1.DaemonSet)
+	onInitialize func(*appsv1.DaemonSet)
 }
 type unitaryHandlerBuilder unitaryHandler
 
-func (hb *handlerBuilder) OnInitialize(fn func([]*extv1beta1.DaemonSet)) HandlerBuilder {
+func (hb *handlerBuilder) OnInitialize(fn func([]*appsv1.DaemonSet)) HandlerBuilder {
 	hb.onInitialize = fn
 	return hb
 }
 
-func (hb *handlerBuilder) OnCreate(fn func(*extv1beta1.DaemonSet)) HandlerBuilder {
+func (hb *handlerBuilder) OnCreate(fn func(*appsv1.DaemonSet)) HandlerBuilder {
 	hb.onCreate = fn
 	return hb
 }
 
-func (hb *handlerBuilder) OnUpdate(fn func(*extv1beta1.DaemonSet)) HandlerBuilder {
+func (hb *handlerBuilder) OnUpdate(fn func(*appsv1.DaemonSet)) HandlerBuilder {
 	hb.onUpdate = fn
 	return hb
 }
 
-func (hb *handlerBuilder) OnDelete(fn func(*extv1beta1.DaemonSet)) HandlerBuilder {
+func (hb *handlerBuilder) OnDelete(fn func(*appsv1.DaemonSet)) HandlerBuilder {
 	hb.onDelete = fn
 	return hb
 }
@@ -450,28 +450,28 @@ func (hb *handlerBuilder) Create() Handler {
 	return handler(*hb)
 }
 
-func (h handler) OnInitialize(objs []*extv1beta1.DaemonSet) {
+func (h handler) OnInitialize(objs []*appsv1.DaemonSet) {
 	if h.onInitialize != nil {
 		h.onInitialize(objs)
 	}
 }
 
-func (hb *unitaryHandlerBuilder) OnInitialize(fn func(*extv1beta1.DaemonSet)) UnitaryHandlerBuilder {
+func (hb *unitaryHandlerBuilder) OnInitialize(fn func(*appsv1.DaemonSet)) UnitaryHandlerBuilder {
 	hb.onInitialize = fn
 	return hb
 }
 
-func (hb *unitaryHandlerBuilder) OnCreate(fn func(*extv1beta1.DaemonSet)) UnitaryHandlerBuilder {
+func (hb *unitaryHandlerBuilder) OnCreate(fn func(*appsv1.DaemonSet)) UnitaryHandlerBuilder {
 	hb.onCreate = fn
 	return hb
 }
 
-func (hb *unitaryHandlerBuilder) OnUpdate(fn func(*extv1beta1.DaemonSet)) UnitaryHandlerBuilder {
+func (hb *unitaryHandlerBuilder) OnUpdate(fn func(*appsv1.DaemonSet)) UnitaryHandlerBuilder {
 	hb.onUpdate = fn
 	return hb
 }
 
-func (hb *unitaryHandlerBuilder) OnDelete(fn func(*extv1beta1.DaemonSet)) UnitaryHandlerBuilder {
+func (hb *unitaryHandlerBuilder) OnDelete(fn func(*appsv1.DaemonSet)) UnitaryHandlerBuilder {
 	hb.onDelete = fn
 	return hb
 }
@@ -480,25 +480,25 @@ func (hb *unitaryHandlerBuilder) Create() UnitaryHandler {
 	return unitaryHandler(*hb)
 }
 
-func (h unitaryHandler) OnInitialize(obj *extv1beta1.DaemonSet) {
+func (h unitaryHandler) OnInitialize(obj *appsv1.DaemonSet) {
 	if h.onInitialize != nil {
 		h.onInitialize(obj)
 	}
 }
 
-func (h baseHandler) OnCreate(obj *extv1beta1.DaemonSet) {
+func (h baseHandler) OnCreate(obj *appsv1.DaemonSet) {
 	if h.onCreate != nil {
 		h.onCreate(obj)
 	}
 }
 
-func (h baseHandler) OnUpdate(obj *extv1beta1.DaemonSet) {
+func (h baseHandler) OnUpdate(obj *appsv1.DaemonSet) {
 	if h.onUpdate != nil {
 		h.onUpdate(obj)
 	}
 }
 
-func (h baseHandler) OnDelete(obj *extv1beta1.DaemonSet) {
+func (h baseHandler) OnDelete(obj *appsv1.DaemonSet) {
 	if h.onDelete != nil {
 		h.onDelete(obj)
 	}

--- a/types/daemonset/generated_test.go
+++ b/types/daemonset/generated_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/watch"
 
 	logutil "github.com/boz/go-logutil"
@@ -44,7 +44,7 @@ func TestController(t *testing.T) {
 
 	fltr := filter.NSName(nsname.New(obj_a.GetNamespace(), obj_a.GetName()))
 
-	list := &extv1beta1.DaemonSetList{
+	list := &appsv1.DaemonSetList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "DaemonSetList",
 			APIVersion: "1",
@@ -52,7 +52,7 @@ func TestController(t *testing.T) {
 		ListMeta: metav1.ListMeta{
 			ResourceVersion: "1",
 		},
-		Items: []extv1beta1.DaemonSet{
+		Items: []appsv1.DaemonSet{
 			*obj_a,
 			*obj_b,
 		},
@@ -310,7 +310,7 @@ func TestMonitor(t *testing.T) {
 	obj_c := testGenObject("ns", "a", "3")
 	obj_d := testGenObject("ns", "b", "4")
 
-	list := &extv1beta1.DaemonSetList{
+	list := &appsv1.DaemonSetList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "DaemonSetList",
 			APIVersion: "1",
@@ -318,7 +318,7 @@ func TestMonitor(t *testing.T) {
 		ListMeta: metav1.ListMeta{
 			ResourceVersion: "1",
 		},
-		Items: []extv1beta1.DaemonSet{
+		Items: []appsv1.DaemonSet{
 			*obj_a,
 		},
 	}
@@ -343,39 +343,39 @@ func TestMonitor(t *testing.T) {
 	u_ucalled := make(chan bool)
 	u_dcalled := make(chan bool)
 
-	h := BuildHandler().OnInitialize(func(objs []*extv1beta1.DaemonSet) {
+	h := BuildHandler().OnInitialize(func(objs []*appsv1.DaemonSet) {
 		if assert.Len(t, objs, 1) {
 			assert.Equal(t, obj_a.GetNamespace(), objs[0].GetNamespace())
 			assert.Equal(t, obj_a.GetName(), objs[0].GetName())
 		}
 		close(icalled)
-	}).OnCreate(func(obj *extv1beta1.DaemonSet) {
+	}).OnCreate(func(obj *appsv1.DaemonSet) {
 		assert.Equal(t, obj_b.GetNamespace(), obj.GetNamespace())
 		assert.Equal(t, obj_b.GetName(), obj.GetName())
 		close(ccalled)
-	}).OnUpdate(func(obj *extv1beta1.DaemonSet) {
+	}).OnUpdate(func(obj *appsv1.DaemonSet) {
 		assert.Equal(t, obj_c.GetNamespace(), obj.GetNamespace())
 		assert.Equal(t, obj_c.GetName(), obj.GetName())
 		close(ucalled)
-	}).OnDelete(func(obj *extv1beta1.DaemonSet) {
+	}).OnDelete(func(obj *appsv1.DaemonSet) {
 		assert.Equal(t, obj_d.GetNamespace(), obj.GetNamespace())
 		assert.Equal(t, obj_d.GetName(), obj.GetName())
 		close(dcalled)
 	}).Create()
 
-	uh := BuildUnitaryHandler().OnInitialize(func(obj *extv1beta1.DaemonSet) {
+	uh := BuildUnitaryHandler().OnInitialize(func(obj *appsv1.DaemonSet) {
 		assert.Equal(t, obj_a.GetNamespace(), obj.GetNamespace())
 		assert.Equal(t, obj_a.GetName(), obj.GetName())
 		close(u_icalled)
-	}).OnCreate(func(obj *extv1beta1.DaemonSet) {
+	}).OnCreate(func(obj *appsv1.DaemonSet) {
 		assert.Equal(t, obj_b.GetNamespace(), obj.GetNamespace())
 		assert.Equal(t, obj_b.GetName(), obj.GetName())
 		close(u_ccalled)
-	}).OnUpdate(func(obj *extv1beta1.DaemonSet) {
+	}).OnUpdate(func(obj *appsv1.DaemonSet) {
 		assert.Equal(t, obj_c.GetNamespace(), obj.GetNamespace())
 		assert.Equal(t, obj_c.GetName(), obj.GetName())
 		close(u_ucalled)
-	}).OnDelete(func(obj *extv1beta1.DaemonSet) {
+	}).OnDelete(func(obj *appsv1.DaemonSet) {
 		assert.Equal(t, obj_d.GetNamespace(), obj.GetNamespace())
 		assert.Equal(t, obj_d.GetName(), obj.GetName())
 		close(u_dcalled)
@@ -461,8 +461,8 @@ func TestMonitor(t *testing.T) {
 
 }
 
-func testGenObject(ns, name, vsn string) *extv1beta1.DaemonSet {
-	return &extv1beta1.DaemonSet{
+func testGenObject(ns, name, vsn string) *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       ns,
 			Name:            name,

--- a/types/deployment/client.go
+++ b/types/deployment/client.go
@@ -8,6 +8,6 @@ import (
 const resourceName = "deployments"
 
 func NewClient(cs kubernetes.Interface, ns string) client.Client {
-	scope := cs.ExtensionsV1beta1()
+	scope := cs.AppsV1()
 	return client.ForResource(scope.RESTClient(), resourceName, ns)
 }

--- a/types/deployment/filter.go
+++ b/types/deployment/filter.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/boz/kcache/filter"
 	"github.com/boz/kcache/nsname"
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 )
 
-func PodsFilter(sources ...*extv1beta1.Deployment) filter.ComparableFilter {
+func PodsFilter(sources ...*appsv1.Deployment) filter.ComparableFilter {
 
 	// make a copy and sort
-	srcs := make([]*extv1beta1.Deployment, len(sources))
+	srcs := make([]*appsv1.Deployment, len(sources))
 	copy(srcs, sources)
 
 	sort.Slice(srcs, func(i, j int) bool {

--- a/types/deployment/filter_test.go
+++ b/types/deployment/filter_test.go
@@ -5,17 +5,17 @@ import (
 
 	"github.com/boz/kcache/types/deployment"
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestPodsFilter_selector(t *testing.T) {
 
-	genselector := func(ns, name string, labels map[string]string) *v1beta1.Deployment {
-		return &v1beta1.Deployment{
+	genselector := func(ns, name string, labels map[string]string) *appsv1.Deployment {
+		return &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name},
-			Spec: v1beta1.DeploymentSpec{
+			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{
 					MatchLabels: labels,
 				},
@@ -23,10 +23,10 @@ func TestPodsFilter_selector(t *testing.T) {
 		}
 	}
 
-	gentemplate := func(ns, name string, labels map[string]string) *v1beta1.Deployment {
-		return &v1beta1.Deployment{
+	gentemplate := func(ns, name string, labels map[string]string) *appsv1.Deployment {
+		return &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{Namespace: ns, Name: name},
-			Spec: v1beta1.DeploymentSpec{
+			Spec: appsv1.DeploymentSpec{
 				Template: v1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{Labels: labels},
 				},
@@ -38,7 +38,7 @@ func TestPodsFilter_selector(t *testing.T) {
 	testPodsFilter(t, gentemplate, "template")
 }
 
-func testPodsFilter(t *testing.T, gen func(string, string, map[string]string) *v1beta1.Deployment, ctx string) {
+func testPodsFilter(t *testing.T, gen func(string, string, map[string]string) *appsv1.Deployment, ctx string) {
 
 	genpod := func(ns string, labels map[string]string) *v1.Pod {
 		return &v1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: labels, Namespace: ns}}

--- a/types/deployment/fiximport.go
+++ b/types/deployment/fiximport.go
@@ -1,9 +1,10 @@
 package deployment
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -14,8 +15,8 @@ var _ corev1.Service
 var _ corev1.Event
 var _ corev1.Node
 var _ corev1.ReplicationController
-var _ extv1beta1.Deployment
-var _ extv1beta1.Ingress
-var _ extv1beta1.ReplicaSet
-var _ extv1beta1.DaemonSet
+var _ appsv1.Deployment
+var _ networkingv1beta1.Ingress
+var _ appsv1.ReplicaSet
+var _ appsv1.DaemonSet
 var _ batchv1.Job

--- a/types/deployment/generated_test.go
+++ b/types/deployment/generated_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/watch"
 
 	logutil "github.com/boz/go-logutil"
@@ -44,7 +44,7 @@ func TestController(t *testing.T) {
 
 	fltr := filter.NSName(nsname.New(obj_a.GetNamespace(), obj_a.GetName()))
 
-	list := &extv1beta1.DeploymentList{
+	list := &appsv1.DeploymentList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "DeploymentList",
 			APIVersion: "1",
@@ -52,7 +52,7 @@ func TestController(t *testing.T) {
 		ListMeta: metav1.ListMeta{
 			ResourceVersion: "1",
 		},
-		Items: []extv1beta1.Deployment{
+		Items: []appsv1.Deployment{
 			*obj_a,
 			*obj_b,
 		},
@@ -310,7 +310,7 @@ func TestMonitor(t *testing.T) {
 	obj_c := testGenObject("ns", "a", "3")
 	obj_d := testGenObject("ns", "b", "4")
 
-	list := &extv1beta1.DeploymentList{
+	list := &appsv1.DeploymentList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "DeploymentList",
 			APIVersion: "1",
@@ -318,7 +318,7 @@ func TestMonitor(t *testing.T) {
 		ListMeta: metav1.ListMeta{
 			ResourceVersion: "1",
 		},
-		Items: []extv1beta1.Deployment{
+		Items: []appsv1.Deployment{
 			*obj_a,
 		},
 	}
@@ -343,39 +343,39 @@ func TestMonitor(t *testing.T) {
 	u_ucalled := make(chan bool)
 	u_dcalled := make(chan bool)
 
-	h := BuildHandler().OnInitialize(func(objs []*extv1beta1.Deployment) {
+	h := BuildHandler().OnInitialize(func(objs []*appsv1.Deployment) {
 		if assert.Len(t, objs, 1) {
 			assert.Equal(t, obj_a.GetNamespace(), objs[0].GetNamespace())
 			assert.Equal(t, obj_a.GetName(), objs[0].GetName())
 		}
 		close(icalled)
-	}).OnCreate(func(obj *extv1beta1.Deployment) {
+	}).OnCreate(func(obj *appsv1.Deployment) {
 		assert.Equal(t, obj_b.GetNamespace(), obj.GetNamespace())
 		assert.Equal(t, obj_b.GetName(), obj.GetName())
 		close(ccalled)
-	}).OnUpdate(func(obj *extv1beta1.Deployment) {
+	}).OnUpdate(func(obj *appsv1.Deployment) {
 		assert.Equal(t, obj_c.GetNamespace(), obj.GetNamespace())
 		assert.Equal(t, obj_c.GetName(), obj.GetName())
 		close(ucalled)
-	}).OnDelete(func(obj *extv1beta1.Deployment) {
+	}).OnDelete(func(obj *appsv1.Deployment) {
 		assert.Equal(t, obj_d.GetNamespace(), obj.GetNamespace())
 		assert.Equal(t, obj_d.GetName(), obj.GetName())
 		close(dcalled)
 	}).Create()
 
-	uh := BuildUnitaryHandler().OnInitialize(func(obj *extv1beta1.Deployment) {
+	uh := BuildUnitaryHandler().OnInitialize(func(obj *appsv1.Deployment) {
 		assert.Equal(t, obj_a.GetNamespace(), obj.GetNamespace())
 		assert.Equal(t, obj_a.GetName(), obj.GetName())
 		close(u_icalled)
-	}).OnCreate(func(obj *extv1beta1.Deployment) {
+	}).OnCreate(func(obj *appsv1.Deployment) {
 		assert.Equal(t, obj_b.GetNamespace(), obj.GetNamespace())
 		assert.Equal(t, obj_b.GetName(), obj.GetName())
 		close(u_ccalled)
-	}).OnUpdate(func(obj *extv1beta1.Deployment) {
+	}).OnUpdate(func(obj *appsv1.Deployment) {
 		assert.Equal(t, obj_c.GetNamespace(), obj.GetNamespace())
 		assert.Equal(t, obj_c.GetName(), obj.GetName())
 		close(u_ucalled)
-	}).OnDelete(func(obj *extv1beta1.Deployment) {
+	}).OnDelete(func(obj *appsv1.Deployment) {
 		assert.Equal(t, obj_d.GetNamespace(), obj.GetNamespace())
 		assert.Equal(t, obj_d.GetName(), obj.GetName())
 		close(u_dcalled)
@@ -461,8 +461,8 @@ func TestMonitor(t *testing.T) {
 
 }
 
-func testGenObject(ns, name, vsn string) *extv1beta1.Deployment {
-	return &extv1beta1.Deployment{
+func testGenObject(ns, name, vsn string) *appsv1.Deployment {
+	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       ns,
 			Name:            name,

--- a/types/event/fiximport.go
+++ b/types/event/fiximport.go
@@ -1,9 +1,10 @@
 package event
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -14,8 +15,8 @@ var _ corev1.Service
 var _ corev1.Event
 var _ corev1.Node
 var _ corev1.ReplicationController
-var _ extv1beta1.Deployment
-var _ extv1beta1.Ingress
-var _ extv1beta1.ReplicaSet
-var _ extv1beta1.DaemonSet
+var _ appsv1.Deployment
+var _ networkingv1beta1.Ingress
+var _ appsv1.ReplicaSet
+var _ appsv1.DaemonSet
 var _ batchv1.Job

--- a/types/event/generated.go
+++ b/types/event/generated.go
@@ -12,8 +12,8 @@ import (
 	"github.com/boz/kcache"
 	"github.com/boz/kcache/client"
 	"github.com/boz/kcache/filter"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -23,7 +23,7 @@ var (
 	adapter        = _adapter{}
 )
 
-var _ = extv1beta1.Deployment{}
+var _ = appsv1.Deployment{}
 
 type Event interface {
 	Type() kcache.EventType

--- a/types/gen/template.go
+++ b/types/gen/template.go
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 )
 
 var (
@@ -20,7 +20,7 @@ var (
 	adapter        = _adapter{}
 )
 
-var _ = extv1beta1.Deployment{}
+var _ = appsv1.Deployment{}
 
 type ObjectType generic.Type
 

--- a/types/ingress/client.go
+++ b/types/ingress/client.go
@@ -8,6 +8,6 @@ import (
 const resourceName = "ingresses"
 
 func NewClient(cs kubernetes.Interface, ns string) client.Client {
-	scope := cs.ExtensionsV1beta1()
+	scope := cs.NetworkingV1beta1()
 	return client.ForResource(scope.RESTClient(), resourceName, ns)
 }

--- a/types/ingress/filter.go
+++ b/types/ingress/filter.go
@@ -3,10 +3,10 @@ package ingress
 import (
 	"github.com/boz/kcache/filter"
 	"github.com/boz/kcache/nsname"
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	appsv1 "k8s.io/api/networking/v1beta1"
 )
 
-func ServicesFilter(ingresses ...*extv1beta1.Ingress) filter.ComparableFilter {
+func ServicesFilter(ingresses ...*appsv1.Ingress) filter.ComparableFilter {
 	var ids []nsname.NSName
 
 	for _, ing := range ingresses {
@@ -16,7 +16,7 @@ func ServicesFilter(ingresses ...*extv1beta1.Ingress) filter.ComparableFilter {
 	return filter.NSName(ids...)
 }
 
-func buildServicesFilter(ing *extv1beta1.Ingress) []nsname.NSName {
+func buildServicesFilter(ing *appsv1.Ingress) []nsname.NSName {
 	var ids []nsname.NSName
 
 	if be := ing.Spec.Backend; be != nil && be.ServiceName != "" {

--- a/types/ingress/filter_test.go
+++ b/types/ingress/filter_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/types/ingress/fiximport.go
+++ b/types/ingress/fiximport.go
@@ -1,9 +1,10 @@
 package ingress
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -14,8 +15,8 @@ var _ corev1.Service
 var _ corev1.Event
 var _ corev1.Node
 var _ corev1.ReplicationController
-var _ extv1beta1.Deployment
-var _ extv1beta1.Ingress
-var _ extv1beta1.ReplicaSet
-var _ extv1beta1.DaemonSet
+var _ appsv1.Deployment
+var _ networkingv1beta1.Ingress
+var _ appsv1.ReplicaSet
+var _ appsv1.DaemonSet
 var _ batchv1.Job

--- a/types/ingress/generated_test.go
+++ b/types/ingress/generated_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/watch"
 
 	logutil "github.com/boz/go-logutil"
@@ -44,7 +44,7 @@ func TestController(t *testing.T) {
 
 	fltr := filter.NSName(nsname.New(obj_a.GetNamespace(), obj_a.GetName()))
 
-	list := &extv1beta1.IngressList{
+	list := &networkingv1beta1.IngressList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "IngressList",
 			APIVersion: "1",
@@ -52,7 +52,7 @@ func TestController(t *testing.T) {
 		ListMeta: metav1.ListMeta{
 			ResourceVersion: "1",
 		},
-		Items: []extv1beta1.Ingress{
+		Items: []networkingv1beta1.Ingress{
 			*obj_a,
 			*obj_b,
 		},
@@ -310,7 +310,7 @@ func TestMonitor(t *testing.T) {
 	obj_c := testGenObject("ns", "a", "3")
 	obj_d := testGenObject("ns", "b", "4")
 
-	list := &extv1beta1.IngressList{
+	list := &networkingv1beta1.IngressList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "IngressList",
 			APIVersion: "1",
@@ -318,7 +318,7 @@ func TestMonitor(t *testing.T) {
 		ListMeta: metav1.ListMeta{
 			ResourceVersion: "1",
 		},
-		Items: []extv1beta1.Ingress{
+		Items: []networkingv1beta1.Ingress{
 			*obj_a,
 		},
 	}
@@ -343,39 +343,39 @@ func TestMonitor(t *testing.T) {
 	u_ucalled := make(chan bool)
 	u_dcalled := make(chan bool)
 
-	h := BuildHandler().OnInitialize(func(objs []*extv1beta1.Ingress) {
+	h := BuildHandler().OnInitialize(func(objs []*networkingv1beta1.Ingress) {
 		if assert.Len(t, objs, 1) {
 			assert.Equal(t, obj_a.GetNamespace(), objs[0].GetNamespace())
 			assert.Equal(t, obj_a.GetName(), objs[0].GetName())
 		}
 		close(icalled)
-	}).OnCreate(func(obj *extv1beta1.Ingress) {
+	}).OnCreate(func(obj *networkingv1beta1.Ingress) {
 		assert.Equal(t, obj_b.GetNamespace(), obj.GetNamespace())
 		assert.Equal(t, obj_b.GetName(), obj.GetName())
 		close(ccalled)
-	}).OnUpdate(func(obj *extv1beta1.Ingress) {
+	}).OnUpdate(func(obj *networkingv1beta1.Ingress) {
 		assert.Equal(t, obj_c.GetNamespace(), obj.GetNamespace())
 		assert.Equal(t, obj_c.GetName(), obj.GetName())
 		close(ucalled)
-	}).OnDelete(func(obj *extv1beta1.Ingress) {
+	}).OnDelete(func(obj *networkingv1beta1.Ingress) {
 		assert.Equal(t, obj_d.GetNamespace(), obj.GetNamespace())
 		assert.Equal(t, obj_d.GetName(), obj.GetName())
 		close(dcalled)
 	}).Create()
 
-	uh := BuildUnitaryHandler().OnInitialize(func(obj *extv1beta1.Ingress) {
+	uh := BuildUnitaryHandler().OnInitialize(func(obj *networkingv1beta1.Ingress) {
 		assert.Equal(t, obj_a.GetNamespace(), obj.GetNamespace())
 		assert.Equal(t, obj_a.GetName(), obj.GetName())
 		close(u_icalled)
-	}).OnCreate(func(obj *extv1beta1.Ingress) {
+	}).OnCreate(func(obj *networkingv1beta1.Ingress) {
 		assert.Equal(t, obj_b.GetNamespace(), obj.GetNamespace())
 		assert.Equal(t, obj_b.GetName(), obj.GetName())
 		close(u_ccalled)
-	}).OnUpdate(func(obj *extv1beta1.Ingress) {
+	}).OnUpdate(func(obj *networkingv1beta1.Ingress) {
 		assert.Equal(t, obj_c.GetNamespace(), obj.GetNamespace())
 		assert.Equal(t, obj_c.GetName(), obj.GetName())
 		close(u_ucalled)
-	}).OnDelete(func(obj *extv1beta1.Ingress) {
+	}).OnDelete(func(obj *networkingv1beta1.Ingress) {
 		assert.Equal(t, obj_d.GetNamespace(), obj.GetNamespace())
 		assert.Equal(t, obj_d.GetName(), obj.GetName())
 		close(u_dcalled)
@@ -461,8 +461,8 @@ func TestMonitor(t *testing.T) {
 
 }
 
-func testGenObject(ns, name, vsn string) *extv1beta1.Ingress {
-	return &extv1beta1.Ingress{
+func testGenObject(ns, name, vsn string) *networkingv1beta1.Ingress {
+	return &networkingv1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       ns,
 			Name:            name,

--- a/types/job/fiximport.go
+++ b/types/job/fiximport.go
@@ -1,10 +1,11 @@
 package job
 
 import (
-	corev1 "k8s.io/api/core/v1"
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ metav1.Object
@@ -14,8 +15,8 @@ var _ corev1.Service
 var _ corev1.Event
 var _ corev1.Node
 var _ corev1.ReplicationController
-var _ extv1beta1.Deployment
-var _ extv1beta1.Ingress
-var _ extv1beta1.ReplicaSet
-var _ extv1beta1.DaemonSet
+var _ appsv1.Deployment
+var _ networkingv1beta1.Ingress
+var _ appsv1.ReplicaSet
+var _ appsv1.DaemonSet
 var _ batchv1.Job

--- a/types/job/generated.go
+++ b/types/job/generated.go
@@ -12,8 +12,8 @@ import (
 	"github.com/boz/kcache"
 	"github.com/boz/kcache/client"
 	"github.com/boz/kcache/filter"
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -23,7 +23,7 @@ var (
 	adapter        = _adapter{}
 )
 
-var _ = extv1beta1.Deployment{}
+var _ = appsv1.Deployment{}
 
 type Event interface {
 	Type() kcache.EventType

--- a/types/node/fiximport.go
+++ b/types/node/fiximport.go
@@ -1,9 +1,10 @@
 package node
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -14,8 +15,8 @@ var _ corev1.Service
 var _ corev1.Event
 var _ corev1.Node
 var _ corev1.ReplicationController
-var _ extv1beta1.Deployment
-var _ extv1beta1.Ingress
-var _ extv1beta1.ReplicaSet
-var _ extv1beta1.DaemonSet
+var _ appsv1.Deployment
+var _ networkingv1beta1.Ingress
+var _ appsv1.ReplicaSet
+var _ appsv1.DaemonSet
 var _ batchv1.Job

--- a/types/node/generated.go
+++ b/types/node/generated.go
@@ -12,8 +12,8 @@ import (
 	"github.com/boz/kcache"
 	"github.com/boz/kcache/client"
 	"github.com/boz/kcache/filter"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -23,7 +23,7 @@ var (
 	adapter        = _adapter{}
 )
 
-var _ = extv1beta1.Deployment{}
+var _ = appsv1.Deployment{}
 
 type Event interface {
 	Type() kcache.EventType

--- a/types/pod/fiximport.go
+++ b/types/pod/fiximport.go
@@ -1,9 +1,10 @@
 package pod
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -14,8 +15,8 @@ var _ corev1.Service
 var _ corev1.Event
 var _ corev1.Node
 var _ corev1.ReplicationController
-var _ extv1beta1.Deployment
-var _ extv1beta1.Ingress
-var _ extv1beta1.ReplicaSet
-var _ extv1beta1.DaemonSet
+var _ appsv1.Deployment
+var _ networkingv1beta1.Ingress
+var _ appsv1.ReplicaSet
+var _ appsv1.DaemonSet
 var _ batchv1.Job

--- a/types/pod/generated.go
+++ b/types/pod/generated.go
@@ -12,8 +12,8 @@ import (
 	"github.com/boz/kcache"
 	"github.com/boz/kcache/client"
 	"github.com/boz/kcache/filter"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -23,7 +23,7 @@ var (
 	adapter        = _adapter{}
 )
 
-var _ = extv1beta1.Deployment{}
+var _ = appsv1.Deployment{}
 
 type Event interface {
 	Type() kcache.EventType

--- a/types/replicaset/client.go
+++ b/types/replicaset/client.go
@@ -8,6 +8,6 @@ import (
 const resourceName = "replicasets"
 
 func NewClient(cs kubernetes.Interface, ns string) client.Client {
-	scope := cs.ExtensionsV1beta1()
+	scope := cs.AppsV1()
 	return client.ForResource(scope.RESTClient(), resourceName, ns)
 }

--- a/types/replicaset/filter.go
+++ b/types/replicaset/filter.go
@@ -3,16 +3,16 @@ package replicaset
 import (
 	"sort"
 
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 
 	"github.com/boz/kcache/filter"
 	"github.com/boz/kcache/nsname"
 )
 
-func PodsFilter(sources ...*extv1beta1.ReplicaSet) filter.ComparableFilter {
+func PodsFilter(sources ...*appsv1.ReplicaSet) filter.ComparableFilter {
 
 	// make a copy and sort
-	srcs := make([]*extv1beta1.ReplicaSet, len(sources))
+	srcs := make([]*appsv1.ReplicaSet, len(sources))
 	copy(srcs, sources)
 
 	sort.Slice(srcs, func(i, j int) bool {

--- a/types/replicaset/filter_test.go
+++ b/types/replicaset/filter_test.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/boz/kcache/types/replicaset"
 	"github.com/stretchr/testify/assert"
+	v1beta1 "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/types/replicaset/fiximport.go
+++ b/types/replicaset/fiximport.go
@@ -1,9 +1,10 @@
 package replicaset
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -14,8 +15,8 @@ var _ corev1.Service
 var _ corev1.Event
 var _ corev1.Node
 var _ corev1.ReplicationController
-var _ extv1beta1.Deployment
-var _ extv1beta1.Ingress
-var _ extv1beta1.ReplicaSet
-var _ extv1beta1.DaemonSet
+var _ appsv1.Deployment
+var _ networkingv1beta1.Ingress
+var _ appsv1.ReplicaSet
+var _ appsv1.DaemonSet
 var _ batchv1.Job

--- a/types/replicaset/generated_test.go
+++ b/types/replicaset/generated_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/watch"
 
 	logutil "github.com/boz/go-logutil"
@@ -44,7 +44,7 @@ func TestController(t *testing.T) {
 
 	fltr := filter.NSName(nsname.New(obj_a.GetNamespace(), obj_a.GetName()))
 
-	list := &extv1beta1.ReplicaSetList{
+	list := &appsv1.ReplicaSetList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ReplicaSetList",
 			APIVersion: "1",
@@ -52,7 +52,7 @@ func TestController(t *testing.T) {
 		ListMeta: metav1.ListMeta{
 			ResourceVersion: "1",
 		},
-		Items: []extv1beta1.ReplicaSet{
+		Items: []appsv1.ReplicaSet{
 			*obj_a,
 			*obj_b,
 		},
@@ -310,7 +310,7 @@ func TestMonitor(t *testing.T) {
 	obj_c := testGenObject("ns", "a", "3")
 	obj_d := testGenObject("ns", "b", "4")
 
-	list := &extv1beta1.ReplicaSetList{
+	list := &appsv1.ReplicaSetList{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ReplicaSetList",
 			APIVersion: "1",
@@ -318,7 +318,7 @@ func TestMonitor(t *testing.T) {
 		ListMeta: metav1.ListMeta{
 			ResourceVersion: "1",
 		},
-		Items: []extv1beta1.ReplicaSet{
+		Items: []appsv1.ReplicaSet{
 			*obj_a,
 		},
 	}
@@ -343,39 +343,39 @@ func TestMonitor(t *testing.T) {
 	u_ucalled := make(chan bool)
 	u_dcalled := make(chan bool)
 
-	h := BuildHandler().OnInitialize(func(objs []*extv1beta1.ReplicaSet) {
+	h := BuildHandler().OnInitialize(func(objs []*appsv1.ReplicaSet) {
 		if assert.Len(t, objs, 1) {
 			assert.Equal(t, obj_a.GetNamespace(), objs[0].GetNamespace())
 			assert.Equal(t, obj_a.GetName(), objs[0].GetName())
 		}
 		close(icalled)
-	}).OnCreate(func(obj *extv1beta1.ReplicaSet) {
+	}).OnCreate(func(obj *appsv1.ReplicaSet) {
 		assert.Equal(t, obj_b.GetNamespace(), obj.GetNamespace())
 		assert.Equal(t, obj_b.GetName(), obj.GetName())
 		close(ccalled)
-	}).OnUpdate(func(obj *extv1beta1.ReplicaSet) {
+	}).OnUpdate(func(obj *appsv1.ReplicaSet) {
 		assert.Equal(t, obj_c.GetNamespace(), obj.GetNamespace())
 		assert.Equal(t, obj_c.GetName(), obj.GetName())
 		close(ucalled)
-	}).OnDelete(func(obj *extv1beta1.ReplicaSet) {
+	}).OnDelete(func(obj *appsv1.ReplicaSet) {
 		assert.Equal(t, obj_d.GetNamespace(), obj.GetNamespace())
 		assert.Equal(t, obj_d.GetName(), obj.GetName())
 		close(dcalled)
 	}).Create()
 
-	uh := BuildUnitaryHandler().OnInitialize(func(obj *extv1beta1.ReplicaSet) {
+	uh := BuildUnitaryHandler().OnInitialize(func(obj *appsv1.ReplicaSet) {
 		assert.Equal(t, obj_a.GetNamespace(), obj.GetNamespace())
 		assert.Equal(t, obj_a.GetName(), obj.GetName())
 		close(u_icalled)
-	}).OnCreate(func(obj *extv1beta1.ReplicaSet) {
+	}).OnCreate(func(obj *appsv1.ReplicaSet) {
 		assert.Equal(t, obj_b.GetNamespace(), obj.GetNamespace())
 		assert.Equal(t, obj_b.GetName(), obj.GetName())
 		close(u_ccalled)
-	}).OnUpdate(func(obj *extv1beta1.ReplicaSet) {
+	}).OnUpdate(func(obj *appsv1.ReplicaSet) {
 		assert.Equal(t, obj_c.GetNamespace(), obj.GetNamespace())
 		assert.Equal(t, obj_c.GetName(), obj.GetName())
 		close(u_ucalled)
-	}).OnDelete(func(obj *extv1beta1.ReplicaSet) {
+	}).OnDelete(func(obj *appsv1.ReplicaSet) {
 		assert.Equal(t, obj_d.GetNamespace(), obj.GetNamespace())
 		assert.Equal(t, obj_d.GetName(), obj.GetName())
 		close(u_dcalled)
@@ -461,8 +461,8 @@ func TestMonitor(t *testing.T) {
 
 }
 
-func testGenObject(ns, name, vsn string) *extv1beta1.ReplicaSet {
-	return &extv1beta1.ReplicaSet{
+func testGenObject(ns, name, vsn string) *appsv1.ReplicaSet {
+	return &appsv1.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:       ns,
 			Name:            name,

--- a/types/replicationcontroller/fiximport.go
+++ b/types/replicationcontroller/fiximport.go
@@ -1,9 +1,10 @@
 package replicationcontroller
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -14,8 +15,8 @@ var _ corev1.Service
 var _ corev1.Event
 var _ corev1.Node
 var _ corev1.ReplicationController
-var _ extv1beta1.Deployment
-var _ extv1beta1.Ingress
-var _ extv1beta1.ReplicaSet
-var _ extv1beta1.DaemonSet
+var _ appsv1.Deployment
+var _ networkingv1beta1.Ingress
+var _ appsv1.ReplicaSet
+var _ appsv1.DaemonSet
 var _ batchv1.Job

--- a/types/replicationcontroller/generated.go
+++ b/types/replicationcontroller/generated.go
@@ -12,8 +12,8 @@ import (
 	"github.com/boz/kcache"
 	"github.com/boz/kcache/client"
 	"github.com/boz/kcache/filter"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -23,7 +23,7 @@ var (
 	adapter        = _adapter{}
 )
 
-var _ = extv1beta1.Deployment{}
+var _ = appsv1.Deployment{}
 
 type Event interface {
 	Type() kcache.EventType

--- a/types/secret/fiximport.go
+++ b/types/secret/fiximport.go
@@ -1,9 +1,10 @@
 package secret
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -14,8 +15,8 @@ var _ corev1.Service
 var _ corev1.Event
 var _ corev1.Node
 var _ corev1.ReplicationController
-var _ extv1beta1.Deployment
-var _ extv1beta1.Ingress
-var _ extv1beta1.ReplicaSet
-var _ extv1beta1.DaemonSet
+var _ appsv1.Deployment
+var _ networkingv1beta1.Ingress
+var _ appsv1.ReplicaSet
+var _ appsv1.DaemonSet
 var _ batchv1.Job

--- a/types/secret/generated.go
+++ b/types/secret/generated.go
@@ -12,8 +12,8 @@ import (
 	"github.com/boz/kcache"
 	"github.com/boz/kcache/client"
 	"github.com/boz/kcache/filter"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -23,7 +23,7 @@ var (
 	adapter        = _adapter{}
 )
 
-var _ = extv1beta1.Deployment{}
+var _ = appsv1.Deployment{}
 
 type Event interface {
 	Type() kcache.EventType

--- a/types/service/fiximport.go
+++ b/types/service/fiximport.go
@@ -1,9 +1,10 @@
 package service
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -14,8 +15,8 @@ var _ corev1.Service
 var _ corev1.Event
 var _ corev1.Node
 var _ corev1.ReplicationController
-var _ extv1beta1.Deployment
-var _ extv1beta1.Ingress
-var _ extv1beta1.ReplicaSet
-var _ extv1beta1.DaemonSet
+var _ appsv1.Deployment
+var _ networkingv1beta1.Ingress
+var _ appsv1.ReplicaSet
+var _ appsv1.DaemonSet
 var _ batchv1.Job

--- a/types/service/generated.go
+++ b/types/service/generated.go
@@ -12,8 +12,8 @@ import (
 	"github.com/boz/kcache"
 	"github.com/boz/kcache/client"
 	"github.com/boz/kcache/filter"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	extv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 )
@@ -23,7 +23,7 @@ var (
 	adapter        = _adapter{}
 )
 
-var _ = extv1beta1.Deployment{}
+var _ = appsv1.Deployment{}
 
 type Event interface {
 	Type() kcache.EventType


### PR DESCRIPTION
```
networkingv1beta1.Ingress
appsv1.ReplicaSet
appsv1.Deployment
appsv1.Daemonset
```

Older APIs were removed in 1.16
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

Better error when initial listing fails